### PR TITLE
permissions: FLWPLT-1144 Treat these nodes as sets to ignore order

### DIFF
--- a/docs/data-sources/pre_approval_rule.md
+++ b/docs/data-sources/pre_approval_rule.md
@@ -31,9 +31,9 @@ data "lumos_pre_approval_rule" "my_preapprovalrule" {
 - `app_id` (String) The ID of the app associated with this pre-approval rule.
 - `app_instance_id` (String) Optionally, an app has an identifer associated with it's particular instance.
 - `justification` (String) The justification of this preapproval rule.
-- `preapproval_webhooks` (Attributes List) The preapproval webhooks of this preapproval rule. (see [below for nested schema](#nestedatt--preapproval_webhooks))
-- `preapproved_groups` (Attributes List) The preapproved groups of this preapproval rule. (see [below for nested schema](#nestedatt--preapproved_groups))
-- `preapproved_permissions` (Attributes List) The preapproved permissions of this preapproval rule. (see [below for nested schema](#nestedatt--preapproved_permissions))
+- `preapproval_webhooks` (Attributes Set) The preapproval webhooks of this preapproval rule. (see [below for nested schema](#nestedatt--preapproval_webhooks))
+- `preapproved_groups` (Attributes Set) The preapproved groups of this preapproval rule. (see [below for nested schema](#nestedatt--preapproved_groups))
+- `preapproved_permissions` (Attributes Set) The preapproved permissions of this preapproval rule. (see [below for nested schema](#nestedatt--preapproved_permissions))
 - `preapproved_users_by_attribute` (Attributes List) The set of users this pre-approval rule applies to, defined by attributes that must be true about the user (see [below for nested schema](#nestedatt--preapproved_users_by_attribute))
 - `time_based_access` (List of String) Preapproval rule time access length,
 

--- a/docs/resources/pre_approval_rule.md
+++ b/docs/resources/pre_approval_rule.md
@@ -40,7 +40,7 @@ resource "lumos_pre_approval_rule" "my_preapprovalrule" {
     }
   ]
   time_based_access = [
-    "4 hours"
+    "..."
   ]
 }
 ```
@@ -55,9 +55,9 @@ resource "lumos_pre_approval_rule" "my_preapprovalrule" {
 
 ### Optional
 
-- `preapproval_webhooks` (Attributes List) The preapproval webhooks of this preapproval rule. (see [below for nested schema](#nestedatt--preapproval_webhooks))
-- `preapproved_groups` (Attributes List) The preapproved groups of this preapproval rule. (see [below for nested schema](#nestedatt--preapproved_groups))
-- `preapproved_permissions` (Attributes List) The preapproved permissions of this preapproval rule. (see [below for nested schema](#nestedatt--preapproved_permissions))
+- `preapproval_webhooks` (Attributes Set) The preapproval webhooks of this preapproval rule. (see [below for nested schema](#nestedatt--preapproval_webhooks))
+- `preapproved_groups` (Attributes Set) The preapproved groups of this preapproval rule. (see [below for nested schema](#nestedatt--preapproved_groups))
+- `preapproved_permissions` (Attributes Set) The preapproved permissions of this preapproval rule. (see [below for nested schema](#nestedatt--preapproved_permissions))
 - `preapproved_users_by_attribute` (Attributes List) The set of users this pre-approval rule applies to, defined by attributes that must be true about the user (see [below for nested schema](#nestedatt--preapproved_users_by_attribute))
 - `time_based_access` (List of String) Preapproval rule time access length,
 

--- a/internal/provider/preapprovalrule_data_source.go
+++ b/internal/provider/preapprovalrule_data_source.go
@@ -73,7 +73,7 @@ func (r *PreApprovalRuleDataSource) Schema(ctx context.Context, req datasource.S
 				Computed:    true,
 				Description: `The justification of this preapproval rule.`,
 			},
-			"preapproval_webhooks": schema.ListNestedAttribute{
+			"preapproval_webhooks": schema.SetNestedAttribute{
 				Computed: true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
@@ -96,7 +96,7 @@ func (r *PreApprovalRuleDataSource) Schema(ctx context.Context, req datasource.S
 				},
 				Description: `The preapproval webhooks of this preapproval rule.`,
 			},
-			"preapproved_groups": schema.ListNestedAttribute{
+			"preapproved_groups": schema.SetNestedAttribute{
 				Computed: true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
@@ -132,7 +132,7 @@ func (r *PreApprovalRuleDataSource) Schema(ctx context.Context, req datasource.S
 				},
 				Description: `The preapproved groups of this preapproval rule.`,
 			},
-			"preapproved_permissions": schema.ListNestedAttribute{
+			"preapproved_permissions": schema.SetNestedAttribute{
 				Computed: true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{

--- a/internal/provider/preapprovalrule_resource.go
+++ b/internal/provider/preapprovalrule_resource.go
@@ -84,7 +84,7 @@ func (r *PreApprovalRuleResource) Schema(ctx context.Context, req resource.Schem
 				Required:    true,
 				Description: `The justification of this preapproval rule.`,
 			},
-			"preapproval_webhooks": schema.ListNestedAttribute{
+			"preapproval_webhooks": schema.SetNestedAttribute{
 				Computed: true,
 				Optional: true,
 				NestedObject: schema.NestedAttributeObject{
@@ -115,7 +115,7 @@ func (r *PreApprovalRuleResource) Schema(ctx context.Context, req resource.Schem
 				},
 				Description: `The preapproval webhooks of this preapproval rule.`,
 			},
-			"preapproved_groups": schema.ListNestedAttribute{
+			"preapproved_groups": schema.SetNestedAttribute{
 				Computed: true,
 				Optional: true,
 				NestedObject: schema.NestedAttributeObject{
@@ -158,7 +158,7 @@ func (r *PreApprovalRuleResource) Schema(ctx context.Context, req resource.Schem
 				},
 				Description: `The preapproved groups of this preapproval rule.`,
 			},
-			"preapproved_permissions": schema.ListNestedAttribute{
+			"preapproved_permissions": schema.SetNestedAttribute{
 				Computed: true,
 				Optional: true,
 				NestedObject: schema.NestedAttributeObject{

--- a/internal/sdk/models/shared/preapprovalruleinput.go
+++ b/internal/sdk/models/shared/preapprovalruleinput.go
@@ -3,6 +3,10 @@
 
 package shared
 
+import (
+	"github.com/teamlumos/terraform-provider-lumos/internal/sdk/internal/utils"
+)
+
 type PreApprovalRuleInput struct {
 	// The justification of this preapproval rule.
 	Justification string `json:"justification"`
@@ -11,13 +15,24 @@ type PreApprovalRuleInput struct {
 	// The ID of the app associated with this pre-approval rule.
 	AppID string `json:"app_id"`
 	// The preapproved groups of this preapproval rule.
-	PreapprovedGroups []BaseGroup `json:"preapproved_groups,omitempty"`
+	PreapprovedGroups []BaseGroup `json:"preapproved_groups"`
 	// The preapproved permissions of this preapproval rule.
-	PreapprovedPermissions []RequestablePermissionBase `json:"preapproved_permissions,omitempty"`
+	PreapprovedPermissions []RequestablePermissionBase `json:"preapproved_permissions"`
 	// The set of users this pre-approval rule applies to, defined by attributes that must be true about the user
 	PreapprovedUsersByAttribute []AttributeEqualityRule `json:"preapproved_users_by_attribute,omitempty"`
 	// The preapproval webhooks of this preapproval rule.
-	PreapprovalWebhooks []BaseInlineWebhook `json:"preapproval_webhooks,omitempty"`
+	PreapprovalWebhooks []BaseInlineWebhook `json:"preapproval_webhooks"`
+}
+
+func (p PreApprovalRuleInput) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(p, "", false)
+}
+
+func (p *PreApprovalRuleInput) UnmarshalJSON(data []byte) error {
+	if err := utils.UnmarshalJSON(data, &p, "", false, nil); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (p *PreApprovalRuleInput) GetJustification() string {

--- a/internal/sdk/models/shared/preapprovalruleoutput.go
+++ b/internal/sdk/models/shared/preapprovalruleoutput.go
@@ -3,6 +3,10 @@
 
 package shared
 
+import (
+	"github.com/teamlumos/terraform-provider-lumos/internal/sdk/internal/utils"
+)
+
 type PreApprovalRuleOutput struct {
 	// The justification of this preapproval rule.
 	Justification string `json:"justification"`
@@ -17,13 +21,24 @@ type PreApprovalRuleOutput struct {
 	// Optionally, an app has an identifer associated with it's particular instance.
 	AppInstanceID string `json:"app_instance_id"`
 	// The preapproved groups of this preapproval rule.
-	PreapprovedGroups []Group `json:"preapproved_groups,omitempty"`
+	PreapprovedGroups []Group `json:"preapproved_groups"`
 	// The set of users this pre-approval rule applies to, defined by attributes that must be true about the user
 	PreapprovedUsersByAttribute []AttributeEqualityRule `json:"preapproved_users_by_attribute,omitempty"`
 	// The preapproved permissions of this preapproval rule.
-	PreapprovedPermissions []RequestablePermissionBaseOutput `json:"preapproved_permissions,omitempty"`
+	PreapprovedPermissions []RequestablePermissionBaseOutput `json:"preapproved_permissions"`
 	// The preapproval webhooks of this preapproval rule.
-	PreapprovalWebhooks []InlineWebhook `json:"preapproval_webhooks,omitempty"`
+	PreapprovalWebhooks []InlineWebhook `json:"preapproval_webhooks"`
+}
+
+func (p PreApprovalRuleOutput) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(p, "", false)
+}
+
+func (p *PreApprovalRuleOutput) UnmarshalJSON(data []byte) error {
+	if err := utils.UnmarshalJSON(data, &p, "", false, nil); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (p *PreApprovalRuleOutput) GetJustification() string {

--- a/internal/sdk/models/shared/preapprovalruleupdateinput.go
+++ b/internal/sdk/models/shared/preapprovalruleupdateinput.go
@@ -3,19 +3,34 @@
 
 package shared
 
+import (
+	"github.com/teamlumos/terraform-provider-lumos/internal/sdk/internal/utils"
+)
+
 type PreApprovalRuleUpdateInput struct {
 	// The justification of this preapproval rule.
 	Justification string `json:"justification"`
 	// Preapproval rule time access length,
 	TimeBasedAccess []string `json:"time_based_access,omitempty"`
 	// The preapproved groups of this preapproval rule.
-	PreapprovedGroups []BaseGroup `json:"preapproved_groups,omitempty"`
+	PreapprovedGroups []BaseGroup `json:"preapproved_groups"`
 	// The preapproved permissions of this preapproval rule.
-	PreapprovedPermissions []RequestablePermissionBase `json:"preapproved_permissions,omitempty"`
+	PreapprovedPermissions []RequestablePermissionBase `json:"preapproved_permissions"`
 	// The set of users this pre-approval rule applies to, defined by attributes that must be true about the user
 	PreapprovedUsersByAttribute []AttributeEqualityRule `json:"preapproved_users_by_attribute,omitempty"`
 	// The preapproval webhooks of this preapproval rule.
-	PreapprovalWebhooks []BaseInlineWebhook `json:"preapproval_webhooks,omitempty"`
+	PreapprovalWebhooks []BaseInlineWebhook `json:"preapproval_webhooks"`
+}
+
+func (p PreApprovalRuleUpdateInput) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(p, "", false)
+}
+
+func (p *PreApprovalRuleUpdateInput) UnmarshalJSON(data []byte) error {
+	if err := utils.UnmarshalJSON(data, &p, "", false, nil); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (p *PreApprovalRuleUpdateInput) GetJustification() string {

--- a/overlay.yaml
+++ b/overlay.yaml
@@ -192,6 +192,40 @@ actions:
     update:
       "x-speakeasy-param-suppress-computed-diff": true
 
+  # Pre Approval Rules - ensure that ordering does not matter for relationship-backed
+  # collections. The API returns these in a non-deterministic / internal-id-sorted order
+  # that won't match the order declared in HCL, producing perpetual Terraform diffs when
+  # modeled as lists (FLWPLT-1144 / FLWPLT-1154). Treating them as sets makes the diff
+  # order-independent. Input, UpdateInput, and Output must all be converted to keep the
+  # merged resource schema consistent (create, update, and read paths respectively).
+  - target: $["components"]["schemas"]["PreApprovalRuleInput"]["properties"]["preapproved_permissions"]
+    update:
+      "format": "set"
+  - target: $["components"]["schemas"]["PreApprovalRuleOutput"]["properties"]["preapproved_permissions"]
+    update:
+      "format": "set"
+  - target: $["components"]["schemas"]["PreApprovalRuleInput"]["properties"]["preapproved_groups"]
+    update:
+      "format": "set"
+  - target: $["components"]["schemas"]["PreApprovalRuleOutput"]["properties"]["preapproved_groups"]
+    update:
+      "format": "set"
+  - target: $["components"]["schemas"]["PreApprovalRuleInput"]["properties"]["preapproval_webhooks"]
+    update:
+      "format": "set"
+  - target: $["components"]["schemas"]["PreApprovalRuleOutput"]["properties"]["preapproval_webhooks"]
+    update:
+      "format": "set"
+  - target: $["components"]["schemas"]["PreApprovalRuleUpdateInput"]["properties"]["preapproved_permissions"]
+    update:
+      "format": "set"
+  - target: $["components"]["schemas"]["PreApprovalRuleUpdateInput"]["properties"]["preapproved_groups"]
+    update:
+      "format": "set"
+  - target: $["components"]["schemas"]["PreApprovalRuleUpdateInput"]["properties"]["preapproval_webhooks"]
+    update:
+      "format": "set"
+
   # Access Policies - Add x-speakeasy-type-override to access_condition
   # so that it can be constructed as a JSON object.
   - target: $["components"]["schemas"]["AccessPolicyInput"]["properties"]["access_condition"]


### PR DESCRIPTION
Customers experience issues with our terraform output randomly sorting permissions differently in subsequent runs. This change aims to treat them as sets so we only diff based on membership, not order.

Is this all I need to do? Or is there more that should be in this PR?

I just tested this locally by applying a simple change to QA and then swapping the permission order in the resource.tf file.

Created with:
```
  preapproved_permissions = [
    { id = "e31211ad-de76-4af7-19ba-5091eef3b974" },
    { id = "03ffc1f3-0d54-aa86-cd74-e6356f502d53" },
  ]
```

Then applied:
```
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Then swapped to:
```
  preapproved_permissions = [
    { id = "03ffc1f3-0d54-aa86-cd74-e6356f502d53" },
    { id = "e31211ad-de76-4af7-19ba-5091eef3b974" },
  ]
```

Then applied:
```
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```