### PR TITLE
Add MIT LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Lumos Identity, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
   <a href="https://speakeasyapi.dev/">
     <img src="https://custom-icon-badges.demolab.com/badge/-Built%20By%20Speakeasy-212015?style=for-the-badge&logoColor=FBE331&logo=speakeasy&labelColor=545454" />
   </a>
+  <a href="LICENSE">
+    <img src="https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge" />
+  </a>
 </div>
 
 The **Lumos Terraform Provider** allows administrators and IAM engineers to manage Lumos configuration—such as apps, permissions, access policies, and pre-approval rules—using Infrastructure as Code.
@@ -21,6 +24,7 @@ This provider is **generated from Lumos’s OpenAPI specification** using [Speak
 - [Release](#release)
 - [Local Development & Testing](#local-development--testing)
 - [Contributions](#contributions)
+- [License](#license)
 - [SDK Created by Speakeasy](#sdk-created-by-speakeasy)
 
 ---
@@ -273,6 +277,12 @@ terraform apply
 While we welcome contributions, this provider is largely generated.
 
 Feel free to open a PR or GitHub issue as a proof of concept, and we’ll work to incorporate changes into future releases.
+
+---
+
+## License
+
+This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add proper `LICENSE` file at the repo root with the standard MIT text (Copyright © 2024 Lumos Identity, Inc.). The repo had no license metadata anywhere — no LICENSE file, no License section in the README — so GitHub, the Terraform Registry, and downstream Go consumers couldn't detect the license.
- Add a License section to the README between Contributions and the Speakeasy footer, with a matching entry in the Table of Contents.
- Add a license badge alongside the existing Speakeasy badge at the top of the README.

No code or build changes; metadata/docs only.

## Notes
- Did not add `LICENSE` to `.genignore`. Speakeasy regen should not touch root-level files it didn't create, but if a future `make provider` wipes the file we'll add it then.

## Test plan
- [ ] After merge, confirm GitHub repo header shows "MIT License" next to the description.
- [ ] On next Terraform Registry sync, confirm the registry page surfaces the MIT license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)